### PR TITLE
Update vim-packages.sh

### DIFF
--- a/vim-packages.sh
+++ b/vim-packages.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-mkdir -p ~/.vim/pack/start/vim-as-a-ruby-ide
+mkdir -p ~/.vim/pack/vim-as-a-ruby-ide/start
 cd ~/.vim/pack/vim-as-a-ruby-ide/start
 
 . ./plugins.sh


### PR DESCRIPTION
New Vim 8+ built-in packaging feature is looking for "vim-as-a-ruby-ide" as the vendor name, and wants all those vendored plugins under the start folder below the vendor name.  This will match the plugins.sh script, as well as allowing the **cd** command to execute (it fails now, and plops all the plugins into the user's CWD).