### PR TITLE
Fix repo for cmdline-completion

### DIFF
--- a/plugins.sh
+++ b/plugins.sh
@@ -18,7 +18,7 @@ git clone https://github.com/scrooloose/syntastic
 
 # Autocompletion
 git clone https://github.com/othree/vim-autocomplpop
-git clone https://github.com/cmdline-completion
+git clone https://github.com/vim-scripts/cmdline-completion
 git clone https://github.com/tpope/vim-endwise
 
 # Snippets


### PR DESCRIPTION
Repository `cmdline-completion` in [plugins.sh](https://github.com/lucerion/vim-as-a-ruby-ide/blob/3340f765e5465fc3dd84593a487df0511ada263e/plugins.sh#L21) doesn't exist.

I think it should be `https://github.com/vim-scripts/cmdline-completion`